### PR TITLE
Update 2023-07-03-li23aq.md

### DIFF
--- a/_posts/2023-07-03-li23aq.md
+++ b/_posts/2023-07-03-li23aq.md
@@ -25,12 +25,12 @@ lastpage: 20383
 page: 20351-20383
 order: 20351
 cycles: false
-bibtex_author: Li, Chris Junchi and Yuan, Angela and Gidel, Gauthier and Gu, Quanquan
+bibtex_author: Li, Chris Junchi and Yuan, Huizhuo and Gidel, Gauthier and Gu, Quanquan
   and Jordan, Michael
 author:
 - given: Chris Junchi
   family: Li
-- given: Angela
+- given: Huizhuo
   family: Yuan
 - given: Gauthier
   family: Gidel


### PR DESCRIPTION
Changed name from Angela Yuan to Huizhuo Yuan, to keep consistent with my publication records. Approved via email by publication chair. Thank you!