### PR TITLE
Fixed capitalisation of co-author's name

### DIFF
--- a/_posts/2023-07-03-von-rohrscheidt23a.md
+++ b/_posts/2023-07-03-von-rohrscheidt23a.md
@@ -23,10 +23,10 @@ lastpage: 35197
 page: 35175-35197
 order: 35175
 cycles: false
-bibtex_author: Von Rohrscheidt, Julius and Rieck, Bastian
+bibtex_author: von Rohrscheidt, Julius and Rieck, Bastian
 author:
 - given: Julius
-  family: Von Rohrscheidt
+  family: von Rohrscheidt
 - given: Bastian
   family: Rieck
 date: 2023-07-03


### PR DESCRIPTION
Just a minor fix for the capitalisation of Julius's name. His family name is "von Rohrscheidt" not "Von Rohrscheidt."